### PR TITLE
updated y18n in package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -420,8 +420,14 @@
             "promise-inflight": "^1.0.1",
             "rimraf": "^2.6.3",
             "ssri": "^6.0.1",
-            "unique-filename": "^1.1.1",
-            "y18n": "^4.0.0"
+            "unique-filename": "^1.1.1"
+          },
+          "dependencies": {
+            "y18n": {
+              "version": "5.0.5",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+              "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+            }
           }
         },
         "glob": {
@@ -1231,8 +1237,14 @@
             "set-blocking": "^2.0.0",
             "string-width": "^3.0.0",
             "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
             "yargs-parser": "^15.0.1"
+          },
+          "dependencies": {
+            "y18n": {
+              "version": "5.0.5",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+              "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+            }
           }
         },
         "yargs-parser": {
@@ -5215,8 +5227,14 @@
             "set-blocking": "^2.0.0",
             "string-width": "^3.0.0",
             "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
             "yargs-parser": "^15.0.1"
+          },
+          "dependencies": {
+            "y18n": {
+              "version": "5.0.5",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+              "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+            }
           }
         },
         "yargs-parser": {
@@ -6108,8 +6126,14 @@
                 "set-blocking": "^2.0.0",
                 "string-width": "^4.2.0",
                 "which-module": "^2.0.0",
-                "y18n": "^4.0.0",
                 "yargs-parser": "^18.1.1"
+              },
+              "dependencies": {
+                "y18n": {
+                  "version": "5.0.5",
+                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+                  "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+                }
               }
             }
           }
@@ -7219,8 +7243,14 @@
             "set-blocking": "^2.0.0",
             "string-width": "^4.2.0",
             "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
             "yargs-parser": "^18.1.1"
+          },
+          "dependencies": {
+            "y18n": {
+              "version": "5.0.5",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+              "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+            }
           }
         },
         "yargs-parser": {
@@ -8011,8 +8041,14 @@
             "promise-inflight": "^1.0.1",
             "rimraf": "^2.6.3",
             "ssri": "^6.0.1",
-            "unique-filename": "^1.1.1",
-            "y18n": "^4.0.0"
+            "unique-filename": "^1.1.1"
+          },
+          "dependencies": {
+            "y18n": {
+              "version": "5.0.5",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+              "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+            }
           }
         },
         "glob": {
@@ -11272,12 +11308,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
-    },
-    "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
     "yallist": {


### PR DESCRIPTION
This update forces use of y18n 5.0.5 to avoid a RCE vulnerability in prior versions