### PR TITLE
bump @types/enzyme to 3.10.8

### DIFF
--- a/fuse-ui-fabric/package.json
+++ b/fuse-ui-fabric/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@fuselab/build-config": "^1.0.0",
-    "@types/enzyme": "3.1.8",
+    "@types/enzyme": "3.10.8",
     "@types/react": "16.8.5",
     "@types/underscore": "^1.8.7",
     "awesome-typescript-loader": "5.2.1",


### PR DESCRIPTION
update @types/enzyme so it uses cheerio correctly, this fixes 'npm build-all'