### PR TITLE
fixed package repository references for y18n

### DIFF
--- a/fuse-ui-fabric/package-lock.json
+++ b/fuse-ui-fabric/package-lock.json
@@ -1138,9 +1138,9 @@
 			}
 		},
 		"@types/cheerio": {
-			"version": "0.22.21",
-			"resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.21.tgz",
-			"integrity": "sha512-aGI3DfswwqgKPiEOTaiHV2ZPC9KEhprpgEbJnv0fZl3SGX0cGgEva1126dGrMC6AJM6v/aihlUgJn9M5DbDZ/Q==",
+			"version": "0.22.23",
+			"resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.23.tgz",
+			"integrity": "sha512-QfHLujVMlGqcS/ePSf3Oe5hK3H8wi/yN2JYuxSB1U10VvW1fO3K8C+mURQesFYS1Hn7lspOsTT75SKq/XtydQg==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
@@ -1153,9 +1153,9 @@
 			"dev": true
 		},
 		"@types/enzyme": {
-			"version": "3.1.8",
-			"resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.1.8.tgz",
-			"integrity": "sha512-HNOmXnm6RvyzVJRue3Ebrb1f609BQ0Lf5eNRCENPD95r6JKTTOwfDDpPE5tVp/fhJiBtvZ3To8a8E1Hq8eExNg==",
+			"version": "3.10.8",
+			"resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.10.8.tgz",
+			"integrity": "sha512-vlOuzqsTHxog6PV79+tvOHFb6hq4QZKMq1lLD9MaWD1oec2lHTKndn76XOpSwCA0oFTaIbKVPrgM3k78Jjd16g==",
 			"dev": true,
 			"requires": {
 				"@types/cheerio": "*",
@@ -2344,11 +2344,13 @@
 				"ssri": "^5.2.4",
 				"unique-filename": "^1.1.0"
 			},
-            "dependencies": {
+			"dependencies": {
 				"y18n": {
-                    "version": "5.0.5"
-                }
-            }
+					"version": "5.0.5",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+					"integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+				}
+			}
 		},
 		"cache-base": {
 			"version": "1.0.1",
@@ -10436,12 +10438,14 @@
 						"rimraf": "^2.6.3",
 						"ssri": "^6.0.1",
 						"unique-filename": "^1.1.1"
-                    },
-                    "dependencies": {
-                        "y18n": {
-                            "version": "5.0.5"
-                        }
-                    }
+					},
+					"dependencies": {
+						"y18n": {
+							"version": "5.0.5",
+							"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+							"integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+						}
+					}
 				},
 				"find-cache-dir": {
 					"version": "2.1.0",
@@ -11259,12 +11263,14 @@
 						"rimraf": "^2.6.3",
 						"ssri": "^6.0.1",
 						"unique-filename": "^1.1.1"
-                    },
-                    "dependencies": {
-                        "y18n": {
-                            "version": "5.0.5"
-                        }
-                    }
+					},
+					"dependencies": {
+						"y18n": {
+							"version": "5.0.5",
+							"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+							"integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+						}
+					}
 				},
 				"find-cache-dir": {
 					"version": "2.1.0",
@@ -12086,11 +12092,13 @@
 						"which-module": "^2.0.0",
 						"yargs-parser": "^13.1.2"
 					},
-                    "dependencies": {
-                        "y18n": {
-                            "version": "5.0.5"
-                        }
-                    }
+					"dependencies": {
+						"y18n": {
+							"version": "5.0.5",
+							"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+							"integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+						}
+					}
 				},
 				"yargs-parser": {
 					"version": "13.1.2",
@@ -12505,11 +12513,13 @@
 						"which-module": "^2.0.0",
 						"yargs-parser": "^13.1.2"
 					},
-                    "dependencies": {
-                        "y18n": {
-                            "version": "5.0.5"
-                        }
-                    }
+					"dependencies": {
+						"y18n": {
+							"version": "5.0.5",
+							"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+							"integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+						}
+					}
 				},
 				"yargs-parser": {
 					"version": "13.1.2",
@@ -12756,7 +12766,6 @@
 				"set-blocking": "^2.0.0",
 				"string-width": "^4.2.0",
 				"which-module": "^2.0.0",
-				"y18n": "^4.0.0",
 				"yargs-parser": "^18.1.2"
 			},
 			"dependencies": {
@@ -12808,6 +12817,11 @@
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 					"dev": true
+				},
+				"y18n": {
+					"version": "5.0.5",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+					"integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
 				}
 			}
 		},
@@ -12820,9 +12834,6 @@
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"
 			}
-		},
-        "y18n": {
-            "version": "5.0.5"
-        }
+		}
 	}
 }


### PR DESCRIPTION
restored hardcoded y18n 5.0.5 references in package lock to populate repository url, hash, etc. - this was a halfway done process for one of the package lock files in a previous PR and needed to be finished for clean installs to work