### PR TITLE
Update package.json to include the repository

### DIFF
--- a/build-config/package.json
+++ b/build-config/package.json
@@ -9,6 +9,11 @@
     "build": "echo no build",
     "build-all": "echo no build-all"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/fuse-webui.git",
+    "directory": "build-config"
+  },
   "author": "hailiu@gmail.com",
   "license": "MS-PL"
 }

--- a/fuse-cli/package.json
+++ b/fuse-cli/package.json
@@ -10,6 +10,11 @@
     "build-prod": "tsc",
     "tslint": "tslint -c tslint.json -t stylish --project tsconfig.json"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/fuse-webui.git",
+    "directory": "fuse-cli"
+  },
   "types": "built/index.d.ts",
   "jest": {
     "moduleFileExtensions": [

--- a/fuse-react-gen/package.json
+++ b/fuse-react-gen/package.json
@@ -13,6 +13,11 @@
     "build-prod": "tsc",
     "tslint": "tslint -c tslint.json -t stylish --project tsconfig.json"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/fuse-webui.git",
+    "directory": "fuse-react-gen"
+  },
   "jest": {
     "moduleFileExtensions": [
       "ts",

--- a/fuse-ui-adal/package.json
+++ b/fuse-ui-adal/package.json
@@ -11,6 +11,11 @@
     "build-all": "webpack & npm run build-node",
     "tslint": "tslint -c tslint.json -t stylish --project tsconfig.json"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/fuse-webui.git",
+    "directory": "fuse-ui-adal"
+  },
   "jest": {
     "moduleFileExtensions": [
       "ts",

--- a/fuse-ui-fabric/package.json
+++ b/fuse-ui-fabric/package.json
@@ -11,6 +11,11 @@
     "build-prod": "npm run build-node",
     "tslint": "tslint -c tslint.json -t stylish --project tsconfig.json"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/fuse-webui.git",
+    "directory": "fuse-ui-fabric"
+  },
   "jest": {
     "moduleFileExtensions": [
       "ts",

--- a/fuse-ui-shared/package.json
+++ b/fuse-ui-shared/package.json
@@ -11,6 +11,11 @@
     "build-prod": "npm run build-node",
     "tslint": "tslint -c tslint.json -t stylish --project tsconfig.json"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/fuse-webui.git",
+    "directory": "fuse-ui-shared"
+  },
   "jest": {
     "moduleFileExtensions": [
       "ts",


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@v-rr](https://github.com/v-rr), [@v-jiepeng](https://github.com/v-jiepeng), [@v-zhzhou](https://github.com/v-zhzhou) and [@v-gjy](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @fuselab/build-config
* @fuselab/cli-utils
* @fuselab/react-gen
* @fuselab/ui-adal
* @fuselab/ui-fabric
* @fuselab/ui-shared